### PR TITLE
Json2csv@4.5.4

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     </div>
     <script src="./moment.js"></script>
     <script src="./moment-timezones.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/json2csv"></script>
+    <script src="https://cdn.jsdelivr.net/npm/json2csv@4.5.4"></script>
     <script>
       var select = document.getElementById("timezoneSelector"),
         timezones = moment.tz.names();

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
     <title>Fitbit Data JSON to .csv File</title>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> 
 <html>
   <head>
     <title>Fitbit Data JSON to .csv File</title>


### PR DESCRIPTION
Since you created this great site, `json2csv` was upgraded.

When `json2csv` upgraded from 4.x to 5.x, the way `flatten` works was changed, which broke your site

[Changelog](https://mircozeiss.com/json2csv/#migrations)

---

![image](https://github.com/iccir919/fitbit-json-to-csv/assets/9329599/763bccfe-ec32-4781-9c78-0837c2f9c52b)

---

So as a result, the `flatten` doesn't work correctly

![image](https://github.com/iccir919/fitbit-json-to-csv/assets/9329599/f0cf6e90-ae3e-4ac8-95a7-cf7afdaeba97)

---

If you change the version of `json2csv` used to `4.5.4`, it works correctly again

![image](https://github.com/iccir919/fitbit-json-to-csv/assets/9329599/94c713b8-7d1b-4bc4-a99a-5af2464a9f76)
