### PR TITLE
off-by-one issue on merge

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       }
 
       function mergeFiles(files, callback) {
-        var count = files.length - 1;
+        var count = files.length;
         var mergedFile = [];
 
         if (!isSameDataType(files)) {


### PR DESCRIPTION
If you merge `n` files, it only merges the first `n-1` files, because `count = files.length-1` when it should be `count = files.length`