### PR TITLE
incorrect filenames

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
               return function(e) {
                 var contents = e.target.result;
                 contents = JSON.parse(contents);
-                handleData(contents, fileName);
+                handleData(contents, theFile.name);
               };
             })(f);
 


### PR DESCRIPTION
Inside the callback function for `reader.onload`, the filename should be specified by `theFile.name` which uses the passed-in `theFile` value, not the `var fileName`, because the `var fileName` is overwritten each time through the loop. 
As a result, every downloaded file has the same name as the last file that was uploaded, not the correct name.